### PR TITLE
hubot用 Docker Image作成

### DIFF
--- a/hubot/Dockerfile
+++ b/hubot/Dockerfile
@@ -1,4 +1,10 @@
 FROM node:alpine
 MAINTAINER tkrplus
 
-CMD bin/hubot --adapter slack
+RUN apk add --update --no-cache git && \
+    rm -rf /var/lib/apt/lists/* && \
+    git clone https://github.com/tkrplus/niwalab-bot.git /niwalab-bot
+
+WORKDIR /niwalab-bot
+
+CMD ["bin/hubot", "--adapter", "slack"]


### PR DESCRIPTION
Image build時にPublicリポジトリからhubotのスクリプトをcloneしているため、
Docker build するときはキャッシュを使用しないこと。
```
$ docker-compose -f docker-compose.hubot.yml build --no-cache
```
